### PR TITLE
FIxes typo in print statement for day 5

### DIFF
--- a/2022/day05/day05.py
+++ b/2022/day05/day05.py
@@ -65,6 +65,6 @@ def top_of_stack(buffer):
     return(ret)
 
 print("part 1 answer is",top_of_stack(perform_movements(lines,init_config,1)))
-print("part 1 answer is",top_of_stack(perform_movements(lines,init_config,2)))
+print("part 2 answer is",top_of_stack(perform_movements(lines,init_config,2)))
 
 


### PR DESCRIPTION
The day 5 python executable file contains helpful print statements at the bottom that communicate the answer to part 1 and part 2 of the puzzle. Currently, the second print statement, meant to print the answer for part 2, is incorrectly labeled as the answer for part 1. This commit aims to remedy this pressing issue.